### PR TITLE
Upgrade to newer `proto-lens` and `http2-grpc-proto-lens`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .stack-work/
+/dist-newstyle/
 gen-bin/
 gen/
 protos/

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,11 @@
+packages: .
+
+allow-newer:
+ , http2-client-grpc:bytestring
+ , http2-client-grpc:http2-client
+ , http2-client-grpc:text
+ , http2-grpc-proto-lens:bytestring
+ , http2-grpc-proto-lens:proto-lens
+ , http2-grpc-types:bytestring
+ , proto-lens-runtime:bytestring
+ , proto-lens:bytestring

--- a/http2-client-grpc-example.cabal
+++ b/http2-client-grpc-example.cabal
@@ -37,7 +37,7 @@ library
                      , process-extras
   default-language:    Haskell2010
 
-executable http2-client-grpc-example-exe
+executable http2-client-grpc-example
   hs-source-dirs:      app
   main-is:             Main.hs
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N

--- a/http2-client-grpc-example.cabal
+++ b/http2-client-grpc-example.cabal
@@ -26,6 +26,7 @@ library
                      , http2
                      , http2-client
                      , http2-client-grpc >= 0.7.0.0
+                     , http2-grpc-proto-lens
                      , http2-grpc-types
                      , lens
                      , lifted-async

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -28,6 +28,7 @@ import Data.ProtoLens.Service.Types (Service(..), HasMethod, HasMethodImpl(..))
 import Network.GRPC.Client
 import Network.GRPC.Client.Helpers
 import Network.GRPC.HTTP2.Encoding
+import Network.GRPC.HTTP2.ProtoLens (RPC (..))
 import Network.HTTP2.Client
 import qualified Network.HTTP2 as HTTP2
 import qualified Network.TLS as TLS
@@ -139,7 +140,7 @@ runExample params@(Params{..}) = runClientIO $ do
         wait streamClientThread
 
         bidirStreamThread <- async $ do
-            let bidiloop :: Int -> ClientIO (Int, BiDiStep GRPCBin "dummyBidirectionalStreamStream" Int )
+            let bidiloop :: Int -> ClientIO (Int, BiDiStep DummyMessage DummyMessage Int )
                 bidiloop n = do
                     printIO "bidi-loop"
                     threadDelay 300000


### PR DESCRIPTION
I tried to use `stack` and a newer Stackage LTS, but I ran into cabal bounds problems that would have required forking a lot of downstream dependencies. Even using `allow-newer` in `stack.yaml` didn't seem to fix the problem, but using `cabal` and `allow-newer` in `cabal.project` gave me what I needed.

Note that I've used explicit types in the client functions rather than using the `MethodInput` and `MethodOutput` type instances generated by `protoc`. I think this makes the code easier to read, and allows for a better match between the function implementation and its type.